### PR TITLE
fix benchmark for pug

### DIFF
--- a/_engines/jade/index.js
+++ b/_engines/jade/index.js
@@ -30,14 +30,14 @@ exports.encode = true;
 exports.prepare = function (data, done) {
   var str = fs.readFileSync(__dirname + '/tpl_escaped.jade', 'utf8');
   tplData = data;
-  compiled = jade.compile(str);
+  compiled = jade.compile(str, { compileDebug: false });
   done();
 };
 
 exports.prepareUnescaped = function (data, done) {
   var str = fs.readFileSync(__dirname + '/tpl_unescaped.jade', 'utf8');
   tplData = data;
-  compiled = jade.compile(str);
+  compiled = jade.compile(str, { compileDebug: false });
   done();
 };
 

--- a/_engines/pug/index.js
+++ b/_engines/pug/index.js
@@ -10,7 +10,7 @@ exports.contributors = 240;
 exports.lastCommit = '9 days ago';
 exports.syntax = 'Short-hand HTML';
 exports.clientSide = false;
-exports.caching = false;
+exports.caching = true;
 exports.asynchronous = false;
 exports.contentBlocks = true;
 exports.partials = true;
@@ -28,18 +28,19 @@ exports.encode = true;
 
 exports.prepare = function (data, done) {
   const file = fs.readFileSync(`${__dirname}/tpl_escaped.pug`, 'utf8');
-  compiled = pug.compile(file);
+  compiled = pug.compile(file, { compileDebug: false });
   tplData = data;
   done();
 };
 
 exports.prepareUnescaped = function (data, done) {
   const file = fs.readFileSync(`${__dirname}/tpl_unescaped.pug`, 'utf8');
-  compiled = pug.compile(file);
+  compiled = pug.compile(file, { compileDebug: false });
   tplData = data;
   done();
 };
 
 exports.step = function (done) {
-  const html = pug.render(compiled, tplData, done);
+  const html = compiled(tplData);
+  done(null, html);
 };

--- a/_engines/pug/tpl_escaped.pug
+++ b/_engines/pug/tpl_escaped.pug
@@ -3,9 +3,8 @@ html
     title= title
   body
     p= text
-    if (projects.length)
-      each project in projects
-        a(href=project.url) project.name
-        p= project.description
+    each project in projects
+      a(href=project.url)= project.name
+      p= project.description
     else
       No projects

--- a/_engines/pug/tpl_unescaped.pug
+++ b/_engines/pug/tpl_unescaped.pug
@@ -3,9 +3,8 @@ html
     title!= title
   body
     p!= text
-    if (projects.length)
-      each project in projects
-        a(href!=project.url)!= project.name
-        p!= project.description
+    each project in projects
+      a(href!=project.url)!= project.name
+      p!= project.description
     else
       No projects


### PR DESCRIPTION
This fixes the benchmark for `pug` (and `jade`):

* sets the option `compileDebug` to `false`
* replaces `pug.render()` with the compiled template.
* improves the template